### PR TITLE
Fix instance description in .env

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -27,7 +27,7 @@ SEARCH_MEILI_INSTANCE=http://localhost:7700
 # require an email address to be invited before being able to sign up
 INVITE_ONLY=__INVITE_ONLY__
 # instance description
-INSTANCE_DESCRIPTION=__INSTANCE_DESCRIPTION__
+INSTANCE_DESCRIPTION="__INSTANCE_DESCRIPTION__"
 
 # uncomment in order to NOT automatically change the database schema when you upgrade the app
 # DISABLE_DB_AUTOMIGRATION=true


### PR DESCRIPTION
`.env` file is broken when `instance_description` contains spaces

## Problem

- an `instance_description` with spaces will break the string and interpret the rest as a command or unintended behavior. If the "_command_" does not exist, bonfire will fail to start. However, it may be worse if the command exists.

## Solution

- double quotation marks around the `instance_description` prevent the string to be split

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

NOTE: I applied the fix on the `master` branch and successfully tested it. I could not test it on the `testing` branch successfully due to other errors arising during installation.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
