### PR TITLE
Default email to yunohost smtp

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -63,9 +63,8 @@ DATABASE_URL=postgresql://__APP__:__DB_PWD__@localhost/__APP__
 MEILI_MASTER_KEY=__MEILI_MASTER_KEY__
 
 # what service to use for sending out emails (eg. smtp, mailgun, none)
-# YunoHost has a built-in mail server (postfix) that apps can use via sendmail
-MAIL_BACKEND=sendmail
-MAIL_SERVER=/usr/sbin/sendmail
+# YunoHost has a built-in mail server
+MAIL_BACKEND=smtp
 MAIL_DOMAIN=__DOMAIN__
 MAIL_PASSWORD=__MAIL_PWD__
 MAIL_USER=__APP__


### PR DESCRIPTION
## Problem

Emails not sending because sendmail is not a part of Yunohost by default

## Solution

Adjusted default config to use smtp of the host system. 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
