### PR TITLE
meili_version key not synchronized with the meilisearch version update.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -74,7 +74,8 @@ ynh_safe_rm "/tmp/libssl_install"
 ynh_script_progression "Installing Meilisearch..."
 
 # Download and install Meilisearch
-meili_version="1.28.1"
+meili_version="$(ynh_read_manifest -m /var/cache/yunohost/repo/default.json -k apps.meilisearch.manifest.version)"
+meili_version="${meili_version/~ynh*/}"
 ynh_setup_source --dest_dir="$install_dir" --source_id="meili"
 chmod +x "$install_dir/meilisearch"
 

--- a/scripts/install
+++ b/scripts/install
@@ -74,7 +74,7 @@ ynh_safe_rm "/tmp/libssl_install"
 ynh_script_progression "Installing Meilisearch..."
 
 # Download and install Meilisearch
-meili_version="$(ynh_read_manifest -m /var/cache/yunohost/repo/default.json -k apps.meilisearch.manifest.version)"
+meili_version="$(jq -r '.apps.meilisearch.manifest.version' /var/cache/yunohost/repo/default.json)"
 meili_version="${meili_version/~ynh*/}"
 ynh_setup_source --dest_dir="$install_dir" --source_id="meili"
 chmod +x "$install_dir/meilisearch"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,7 +30,8 @@ ynh_script_progression "Downloading new Bonfire release..."
 ynh_setup_source --dest_dir="$install_dir" --full_replace
 
 # Download and install Meilisearch
-meili_version="1.28.1"
+meili_version="$(ynh_read_manifest -m /var/cache/yunohost/repo/default.json -k apps.meilisearch.manifest.version)"
+meili_version="${meili_version/~ynh*/}"
 ynh_setup_source --dest_dir="$install_dir" --source_id="meili"
 chmod +x "$install_dir/meilisearch"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,7 +30,7 @@ ynh_script_progression "Downloading new Bonfire release..."
 ynh_setup_source --dest_dir="$install_dir" --full_replace
 
 # Download and install Meilisearch
-meili_version="$(ynh_read_manifest -m /var/cache/yunohost/repo/default.json -k apps.meilisearch.manifest.version)"
+meili_version="$(jq -r '.apps.meilisearch.manifest.version' /var/cache/yunohost/repo/default.json)"
 meili_version="${meili_version/~ynh*/}"
 ynh_setup_source --dest_dir="$install_dir" --source_id="meili"
 chmod +x "$install_dir/meilisearch"


### PR DESCRIPTION
## Problem

`meili_version` is manually set in install and upgrade scripts but meilisearch version is autoupdated.

## Solution

Don't know if it's really reliable but worked. Any feedback welcome !

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)


