### PR TITLE
Upgrade sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Federated social networking server built on ActivityPub open protocol
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://bonfirenetworks.org/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://campground.bonfire.cafe/)
-[![Version: 1.0.0-rc36~ynh7](https://img.shields.io/badge/Version-1.0.0--rc36~ynh7-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/bonfire/)
+[![Version: 1.0.0-rc36~ynh8](https://img.shields.io/badge/Version-1.0.0--rc36~ynh8-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/bonfire/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/bonfire"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Bonfire"
 description.en = "Federated social networking server built on ActivityPub open protocol"
 description.fr = "Serveur de réseautage social fédéré basé sur le protocole ouvert ActivityPub"
 
-version = "1.0.0-rc36~ynh7"
+version = "1.0.0-rc36~ynh8"
 
 maintainers = ["Lapineige"]
 
@@ -125,10 +125,10 @@ ram.runtime = "1000M"
     #autoupdate.asset = "bonfire-social-amd64-debian-bookworm.tar.gz"
 
     [resources.sources.meili]
-    amd64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.34.0/meilisearch-linux-amd64"
-    amd64.sha256 = "4113c9a6083807d62127896892eab688f4d3d99558d99d720530f4d13bd729c6"
-    arm64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.34.0/meilisearch-linux-aarch64"
-    arm64.sha256 = "b19c9fb8da3463b46ada314b7e625c8a22e0df7c6e88302a878c3ea2002bd26d"
+    amd64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.34.2/meilisearch-linux-amd64"
+    amd64.sha256 = "667a7e2de3b5710d46dc61b6140f37d0e4896e6a1559c3bbb853ae878a5eb9d5"
+    arm64.url = "https://github.com/meilisearch/meilisearch/releases/download/v1.34.2/meilisearch-linux-aarch64"
+    arm64.sha256 = "4fb79fa0af29cbc82c59daa0d74bc25c0ad672d718abfe4d5786747fdc03aa6a"
     rename = "meilisearch"
     in_subdir = false
     extract = false


### PR DESCRIPTION
Upgrade sources
- `meili` v1.34.2: https://github.com/meilisearch/meilisearch/releases/tag/v1.34.2